### PR TITLE
Add support for Mount Targon

### DIFF
--- a/src/Faction.js
+++ b/src/Faction.js
@@ -5,15 +5,35 @@ class Faction {
   }
 
   static fromCode (code) {
-    if (!Faction.FACTIONS.includes(code)) throw new TypeError('Invalid faction code!')
-    return new this(code, this.FACTIONS.indexOf(code))
+    const factionId = Faction.FACTIONS[code]
+
+    if (factionId === undefined) {
+      throw new TypeError('Invalid faction code. It is possible you need to upgrade the runeterra package.')
+    }
+
+    return new this(code, factionId)
   }
 
   static fromID (id) {
-    return new this(this.FACTIONS[id], id)
+    const [shortCode, factionId] = Object.entries(Faction.FACTIONS).find(([shortCode, factionId]) => factionId === id) || []
+
+    if (factionId === undefined) {
+      throw new TypeError('Invalid faction id. It is possible you need to upgrade the runeterra package.')
+    }
+
+    return new this(shortCode, factionId)
   }
 }
 
-Faction.FACTIONS = ['DE', 'FR', 'IO', 'NX', 'PZ', 'SI', 'BW']
+Faction.FACTIONS = {
+  DE: 0,
+  FR: 1,
+  IO: 2,
+  NX: 3,
+  PZ: 4,
+  SI: 5,
+  BW: 6,
+  MT: 9
+}
 
 module.exports = Faction

--- a/test/enconding.js
+++ b/test/enconding.js
@@ -41,6 +41,18 @@ describe('Encoding/Decoding', () => {
     assert.deepStrictEqual(deck, decoded)
   })
 
+  it('should decode decks with mount targon cards', () => {
+    const deck = [
+      Card.fromCardString('3:03MT010'),
+      Card.fromCardString('2:03MT003'),
+      Card.fromCardString('4:01DE002'),
+      Card.fromCardString('5:02BW004')
+    ]
+    const code = DeckEncoder.encode(deck)
+    const decoded = DeckEncoder.decode(code)
+    assert.deepStrictEqual(deck, decoded)
+  })
+
   it('should decode large decks', () => {
     const deck = [
       Card.fromCardString('3:01DE002'),


### PR DESCRIPTION
This ends up being very similar to #8 but different in a few ways.

1. This is still using version 2. According to [Riot documentation](https://github.com/RiotGames/LoRDeckCodes#process) version 3 is not yet supported in the client and so that PR will break codes if pushed as-is. 

2. I changed the way faction shortCodes and ids are organized. Rather than using an array it is now using an object. I think this has a few benefits:
    1. When a new region is added, it is much easier to make sure the id is what it is expected to be. Previously, because it was an array the array needed to be filled with null values in order to make sure the region was in the correct location. Imagine in the future a region has id 104 for whatever reason. The array would then need to be 105 items long and make sure that each region is in its correct spot. 
    2. It's much easier to add new regions. When it is an object you can just add it to the end of the object as a key/value pair and not worry about where to put that new region. So whenever a new region is released it is trivial to add the region to the list.

If you prefer the array way then I can put that back, but I figured i'd propose this new way which I think will be easier to digest for future updates.