### PR TITLE
Add support for Shurima

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runeterra",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Legends of Runeterra deck code encoder/decoder",
   "main": "src/index.js",
   "types": "index.d.ts",

--- a/src/DeckEncoder.js
+++ b/src/DeckEncoder.js
@@ -138,6 +138,6 @@ class DeckEncoder {
   }
 }
 
-DeckEncoder.MAX_KNOWN_VERSION = 2
+DeckEncoder.MAX_KNOWN_VERSION = 3
 
 module.exports = DeckEncoder

--- a/src/Faction.js
+++ b/src/Faction.js
@@ -33,7 +33,8 @@ Faction.FACTIONS = {
   PZ: 4,
   SI: 5,
   BW: 6,
-  MT: 9
+  MT: 9,
+  SH: 7
 }
 
 module.exports = Faction

--- a/test/enconding.js
+++ b/test/enconding.js
@@ -53,6 +53,18 @@ describe('Encoding/Decoding', () => {
     assert.deepStrictEqual(deck, decoded)
   })
 
+  it('should decode decks with shurima cards', () => {
+    const deck = [
+      Card.fromCardString('3:04SH010'),
+      Card.fromCardString('2:04SH003'),
+      Card.fromCardString('4:02DE002'),
+      Card.fromCardString('5:03BW004')
+    ]
+    const code = DeckEncoder.encode(deck)
+    const decoded = DeckEncoder.decode(code)
+    assert.deepStrictEqual(deck, decoded)
+  })
+
   it('should decode large decks', () => {
     const deck = [
       Card.fromCardString('3:01DE002'),


### PR DESCRIPTION
I updated the code testing with a Shurima deck to check which code the region has (in Shurima's case, it's 7).
Also added a new test and upgraded the library version, as Danny North's example with the Mount Targon update.

Hope this can help y'all!